### PR TITLE
add apc cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": ">=5.4",
         "ext-mongo": ">=1.2.12,<1.6-dev",
+        "ext-apc": ">=3.0",
         "symfony/symfony": "~2.3",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",

--- a/web/app.php
+++ b/web/app.php
@@ -5,20 +5,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
-// Use APC for autoloading to improve performance.
-// Change 'sf2' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-/*
-$loader = new ApcClassLoader('sf2', $loader);
+$loader = new ApcClassLoader('4blog', $loader);
 $loader->register(true);
-*/
 
 require_once __DIR__.'/../app/AppKernel.php';
-//require_once __DIR__.'/../app/AppCache.php';
+require_once __DIR__.'/../app/AppCache.php';
 
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
-//$kernel = new AppCache($kernel);
+$kernel = new AppCache($kernel);
 Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);


### PR DESCRIPTION
The PSR-0 class loader used in the front controller uses an inefficient storage strategy. Use ApcClassLoader instead.
