### PR TITLE
change cookie name

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,6 +19,7 @@ framework:
     default_locale:  "%locale%"
     trusted_proxies: ~
     session:
+        name: 'blog4devs'
         cookie_domain: "%domain%"
     fragments:       ~
 


### PR DESCRIPTION
The session cookie name is the default one, PHPSESSID. You should consider overwriting it thanks to session.name parameter.
