### PR TITLE
add twig extension for article

### DIFF
--- a/src/FDevs/ArticleBundle/Resources/config/services.xml
+++ b/src/FDevs/ArticleBundle/Resources/config/services.xml
@@ -1,20 +1,33 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
 
-    <!--<parameters>-->
-        <!--<parameter key="f_devs_article.example.class">FDevs\ArticleBundle\Example</parameter>-->
-    <!--</parameters>-->
+    <parameters>
+        <parameter key="f_devs_article.twig.class">FDevs\ArticleBundle\Twig\Extension\ArticleExtension</parameter>
+        <parameter key="f_devs_article.helper.class">FDevs\ArticleBundle\Templating\Helper\ArticleHelper</parameter>
+        <parameter key="bread_crumbs.class">FDevs\ArticleBundle\Service\BreadCrumbs</parameter>
+        <parameter key="fdevs.twig.bread_crumbs_extension.class">FDevs\ArticleBundle\Twig\BreadCrumbsExtension</parameter>
+    </parameters>
 
-    <!--<services>-->
-        <!--<service id="f_devs_article.example" class="%f_devs_article.example.class%">-->
-            <!--<argument type="service" id="service_id" />-->
-            <!--<argument>plain_value</argument>-->
-            <!--<argument>%parameter_name%</argument>-->
-        <!--</service>-->
-    <!--</services>-->
+    <services>
+
+        <service id="fdevs.twig.bread_crumbs_extension" class="%fdevs.twig.bread_crumbs_extension.class%">
+            <argument type="service" id="service_container"/>
+            <tag name="twig.extension"/>
+        </service>
+        <service id="bread_crumbs" class="%bread_crumbs.class%">
+            <argument type="string">/</argument>
+            <argument type="string">active</argument>
+        </service>
+
+        <service id="f_devs_article.helper" class="%f_devs_article.helper.class%"/>
+        <service id="f_devs_article.twig" class="%f_devs_article.twig.class%">
+            <argument type="service" id="f_devs_article.helper"/>
+            <tag name="twig.extension"/>
+        </service>
+    </services>
 
 </container>

--- a/src/FDevs/ArticleBundle/Resources/views/Default/article.html.twig
+++ b/src/FDevs/ArticleBundle/Resources/views/Default/article.html.twig
@@ -39,7 +39,7 @@
                     </div>
                 </header>
                 <div class="article-content">
-                    {{ article.content | raw }}
+                    {{ f_devs_article_render(article) }}
                 </div>
                 <footer>
 

--- a/src/FDevs/ArticleBundle/Resources/views/Default/articleBlock.html.twig
+++ b/src/FDevs/ArticleBundle/Resources/views/Default/articleBlock.html.twig
@@ -24,9 +24,7 @@
             </div>
         </div>
     </header>
-    <div class="content">
-        {{ (article.description?:article.content)| raw }}
-    </div>
+    <div class="content">{{ f_devs_article_render(article,{},'description') }}</div>
     <footer class=row-fluid>
         <div class="span8 article-tags">
             {% for tag in article.tags %}

--- a/src/FDevs/ArticleBundle/Templating/Helper/ArticleHelper.php
+++ b/src/FDevs/ArticleBundle/Templating/Helper/ArticleHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FDevs\ArticleBundle\Templating\Helper;
+
+use FDevs\ArticleBundle\Model\Article;
+use Symfony\Component\Templating\Helper\Helper;
+
+class ArticleHelper extends Helper
+{
+    const SHORT = 'description';
+    const FULL = 'content';
+
+    /**
+     * render Article
+     *
+     * @param  Article $article
+     * @param  array   $parameters
+     * @param  string  $type
+     * @return string
+     */
+    public function render(Article $article, array $parameters = array(), $type = self::FULL)
+    {
+        return $type == self::SHORT && $article->getDescription() ? $article->getDescription() : $article->getContent();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'f_devs_article';
+    }
+}

--- a/src/FDevs/ArticleBundle/Twig/Extension/ArticleExtension.php
+++ b/src/FDevs/ArticleBundle/Twig/Extension/ArticleExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace FDevs\ArticleBundle\Twig\Extension;
+
+use FDevs\ArticleBundle\Model\Article;
+use FDevs\ArticleBundle\Templating\Helper\ArticleHelper;
+
+class ArticleExtension extends \Twig_Extension
+{
+    /**
+     * @var ArticleHelper
+     */
+    protected $helper;
+
+    /**
+     * Constructor.
+     *
+     * @param ArticleHelper $helper
+     */
+    public function __construct(ArticleHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            'f_devs_article_render' => new \Twig_Function_Method($this, 'render', array('is_safe' => array('html'))),
+        );
+    }
+
+    /**
+     * render article
+     *
+     * @param  Article $article
+     * @param  array   $parameters
+     * @param  string  $type
+     * @return string
+     */
+    public function render(Article $article, $parameters = array(), $type = ArticleHelper::FULL)
+    {
+        return $this->helper->render($article, $parameters, $type);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'f_devs_article';
+    }
+}


### PR DESCRIPTION
Using the |raw filter or the {% autoescape false %} block in a Twig template exposes users to Cross-Site Scripting (XSS) attacks
